### PR TITLE
feat: add stabilizer to preserve order of values 

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,4 +1,4 @@
-name: Build Jekyll GitHub Pages site
+name: GitHub Pages
 
 on:
   push:

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,23 @@
+name: License
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go ${{matrix.go-version}}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{matrix.go-version}}
+
+      - name: Check
+        # NOTE: Keep in sync with .hooks/addlicense
+        run: go run github.com/google/addlicense@v1.1.1 -check -s=only -ignore='bin/**' -ignore='**/.terraform.lock.hcl' -ignore='definitions/**' **

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,4 +1,4 @@
-name: Formatting for Markdown and YAML
+name: Markup format
 
 on:
   push:

--- a/.hooks/addlicense
+++ b/.hooks/addlicense
@@ -1,0 +1,2 @@
+#!/bin/sh
+go run github.com/google/addlicense@v1.1.1 -s=only -ignore='bin/**' -ignore='**/.terraform.lock.hcl' -ignore='definitions/**' **

--- a/.hooks/addlicense
+++ b/.hooks/addlicense
@@ -1,2 +1,3 @@
 #!/bin/sh
+# NOTE: Keep in sync with .github/workflow/license.yml
 go run github.com/google/addlicense@v1.1.1 -s=only -ignore='bin/**' -ignore='**/.terraform.lock.hcl' -ignore='definitions/**' **

--- a/build/container/container.go
+++ b/build/container/container.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package container provides routines to programmatically build container components of the project.
 package container

--- a/build/package/Dockerfile.api
+++ b/build/package/Dockerfile.api
@@ -1,8 +1,13 @@
 FROM golang:1.22-alpine as binary
 ARG DEBUG=false
+ARG BUILD_REPO
+ARG BUILD_VERSION
 WORKDIR /src
 COPY . .
-RUN CGO_ENABLED=0 go build -ldflags="$([ ${DEBUG} = "true" ] || printf '-s -w')" -gcflags="-l=4" ./cmd/api
+RUN CGO_ENABLED=0 go build \
+    -ldflags="$([ ${DEBUG} = "true" ] || printf '-s -w') -X main.BuildRepo=${BUILD_REPO} -X main.BuildVersion=${BUILD_VERSION}" \
+    -gcflags="-l=4" \
+    ./cmd/api
 FROM alpine
 COPY --from=binary /src/api /
 ENTRYPOINT ["/api"]

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package main
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // gateway provides a simple HTTP server that redirects to the provided URI applying the configured policy.
 //

--- a/cmd/git_cache/main.go
+++ b/cmd/git_cache/main.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package main implements a git repo cache on GCS.
 //

--- a/cmd/gsutil_writeonly/main.go
+++ b/cmd/gsutil_writeonly/main.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package main
 

--- a/cmd/inference/main.go
+++ b/cmd/inference/main.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package main
 

--- a/cmd/oss-rebuild/main.go
+++ b/cmd/oss-rebuild/main.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package main
 

--- a/cmd/oss-rebuild/verify.go
+++ b/cmd/oss-rebuild/verify.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 // Package main defines an HTTP(S) proxy.
 package main
 

--- a/cmd/rebuilder/main.go
+++ b/cmd/rebuilder/main.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // main contains the smoketest rebuilder, which triggers a rebuild local to this binary (not GCB).
 package main

--- a/cmd/stabilize/main.go
+++ b/cmd/stabilize/main.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/timewarp/main.go
+++ b/cmd/timewarp/main.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // The timewarp binary serves the registry timewarp HTTP handler on a local port.
 package main

--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -1,16 +1,5 @@
-# Copyright 2024 The OSS Rebuild Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
 
 variable "project" {
   type = string

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,16 +1,5 @@
-# Copyright 2024 The OSS Rebuild Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
 
 remote_theme: pages-themes/minimal@v0.2.0
 plugins:

--- a/internal/api/apiservice/createrun.go
+++ b/internal/api/apiservice/createrun.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package apiservice
 
 import (

--- a/internal/api/apiservice/rebuild.go
+++ b/internal/api/apiservice/rebuild.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package apiservice
 
 import (

--- a/internal/api/apiservice/rebuild_test.go
+++ b/internal/api/apiservice/rebuild_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package apiservice
 
 import (

--- a/internal/api/apiservice/smoketest.go
+++ b/internal/api/apiservice/smoketest.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package apiservice
 
 import (

--- a/internal/api/apiservice/smoketest_test.go
+++ b/internal/api/apiservice/smoketest_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package apiservice
 
 import (

--- a/internal/api/apiservice/version.go
+++ b/internal/api/apiservice/version.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package apiservice
 
 import (

--- a/internal/api/form/form.go
+++ b/internal/api/form/form.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package form
 
 import (

--- a/internal/api/form/form_test.go
+++ b/internal/api/form/form_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package form
 
 import (

--- a/internal/api/inferenceservice/infer.go
+++ b/internal/api/inferenceservice/infer.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package inferenceservice
 
 import (

--- a/internal/api/inferenceservice/version.go
+++ b/internal/api/inferenceservice/version.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package inferenceservice
 
 import (

--- a/internal/api/message.go
+++ b/internal/api/message.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package api
 
 // A message is a request/response type, used in api.Stub

--- a/internal/api/rebuilderservice/smoketest.go
+++ b/internal/api/rebuilderservice/smoketest.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package rebuilderservice
 
 import (

--- a/internal/api/rebuilderservice/version.go
+++ b/internal/api/rebuilderservice/version.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package rebuilderservice
 
 import (

--- a/internal/api/rpc.go
+++ b/internal/api/rpc.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package api
 
 import (

--- a/internal/api/rpc_test.go
+++ b/internal/api/rpc_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package api
 
 import (

--- a/internal/bitmap/bitmap.go
+++ b/internal/bitmap/bitmap.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package bitmap
 
 import "math/bits"

--- a/internal/bitmap/bitmap_test.go
+++ b/internal/bitmap/bitmap_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package bitmap
 
 import (

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package cache provides an interface and implementations for caching.
 package cache

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package cache
 

--- a/internal/firestoretest/emulator.go
+++ b/internal/firestoretest/emulator.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package firestoretest
 
 import (

--- a/internal/gateway/client.go
+++ b/internal/gateway/client.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package gateway provides a client for the gateway service.
 package gateway

--- a/internal/gcb/gcb.go
+++ b/internal/gcb/gcb.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package gcb
 

--- a/internal/gcb/gcbtest/mockclient.go
+++ b/internal/gcb/gcbtest/mockclient.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package gcbtest
 
 import (

--- a/internal/gitx/cache.go
+++ b/internal/gitx/cache.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package gitx
 

--- a/internal/gitx/clone.go
+++ b/internal/gitx/clone.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package git provides rebuilder-specific git abstractions.
 package gitx

--- a/internal/gitx/gitxtest/git.go
+++ b/internal/gitx/gitxtest/git.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package gitxtest
 
 import (

--- a/internal/gitx/storage.go
+++ b/internal/gitx/storage.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package gitx
 

--- a/internal/hashext/hashext_test.go
+++ b/internal/hashext/hashext_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package hashext
 

--- a/internal/hashext/multihash.go
+++ b/internal/hashext/multihash.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package hashext
 

--- a/internal/hashext/typedhash.go
+++ b/internal/hashext/typedhash.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package hashext provides extensions to the standard crypto/hash package.
 package hashext

--- a/internal/httpegress/httpegress.go
+++ b/internal/httpegress/httpegress.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package httpegress provides a client constructor for building an HTTP Client for making requests to external services.
 package httpegress

--- a/internal/httpx/http.go
+++ b/internal/httpx/http.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package http provides a simpler http.Client abstraction and derivative uses.
 package httpx

--- a/internal/httpx/httpxtest/mockclient.go
+++ b/internal/httpx/httpxtest/mockclient.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package httpxtest
 
 import (

--- a/internal/llm/llm.go
+++ b/internal/llm/llm.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package llm
 
 import (

--- a/internal/netclassify/classify.go
+++ b/internal/netclassify/classify.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package netclassify
 
 import (

--- a/internal/netclassify/classify_test.go
+++ b/internal/netclassify/classify_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package netclassify
 
 import (

--- a/internal/oauth/identity.go
+++ b/internal/oauth/identity.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package oauth
 

--- a/internal/oauth/oauth.go
+++ b/internal/oauth/oauth.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package oauth
 

--- a/internal/proxy/dockerfs/dockerfs.go
+++ b/internal/proxy/dockerfs/dockerfs.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 // Package dockerfs defines a FS interface for accessing files in a Docker container.
 package dockerfs
 

--- a/internal/proxy/dockerfs/dockerfs_test.go
+++ b/internal/proxy/dockerfs/dockerfs_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package dockerfs
 
 import (

--- a/internal/proxy/handshake/handshake_test.go
+++ b/internal/proxy/handshake/handshake_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package handshake
 
 import (

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package semver implements the Semantic Versioning 2.0.0 spec.
 package semver

--- a/internal/semver/semver_test.go
+++ b/internal/semver/semver_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package semver
 

--- a/internal/taskqueue/taskqueue.go
+++ b/internal/taskqueue/taskqueue.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package taskqueue
 
 import (

--- a/internal/textwrap/textwrap.go
+++ b/internal/textwrap/textwrap.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package textwrap
 
 import (

--- a/internal/textwrap/textwrap_test.go
+++ b/internal/textwrap/textwrap_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package textwrap
 
 import (

--- a/internal/timewarp/timewarp.go
+++ b/internal/timewarp/timewarp.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package timewarp implements a registry-fronting HTTP service that filters returned content by time.
 //

--- a/internal/timewarp/timewarp_test.go
+++ b/internal/timewarp/timewarp_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package timewarp
 
 import (

--- a/internal/uri/uri.go
+++ b/internal/uri/uri.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package uri
 

--- a/internal/uri/uri_test.go
+++ b/internal/uri/uri_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package uri
 

--- a/internal/urlx/urlx.go
+++ b/internal/urlx/urlx.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package urlx
 
 import "net/url"

--- a/internal/verifier/attestation.go
+++ b/internal/verifier/attestation.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package verifier
 

--- a/internal/verifier/attestation_test.go
+++ b/internal/verifier/attestation_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package verifier
 

--- a/internal/verifier/attestor.go
+++ b/internal/verifier/attestor.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package verifier
 

--- a/internal/verifier/intoto.go
+++ b/internal/verifier/intoto.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package verifier
 

--- a/internal/verifier/summary.go
+++ b/internal/verifier/summary.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package verifier provides a library for verifying and attesting to a rebuild.
 package verifier

--- a/internal/verifier/summary_test.go
+++ b/internal/verifier/summary_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package verifier
 

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package archive
 

--- a/pkg/archive/archivetest/tar.go
+++ b/pkg/archive/archivetest/tar.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package archivetest
 
 import (

--- a/pkg/archive/archivetest/zip.go
+++ b/pkg/archive/archivetest/zip.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package archivetest
 
 import (

--- a/pkg/archive/common.go
+++ b/pkg/archive/common.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package archive provides common types and functions for archive processing.
 package archive

--- a/pkg/archive/common_test.go
+++ b/pkg/archive/common_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package archive
 

--- a/pkg/archive/gzip.go
+++ b/pkg/archive/gzip.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package archive
 
 import (

--- a/pkg/archive/gzip_test.go
+++ b/pkg/archive/gzip_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package archive
 
 import (

--- a/pkg/archive/jar.go
+++ b/pkg/archive/jar.go
@@ -2,6 +2,7 @@ package archive
 
 import (
 	"bytes"
+	"sort"
 	"strings"
 )
 
@@ -50,6 +51,52 @@ var StableJARBuildMetadata = ZipEntryStabilizer{
 			"Source-Date-Epoch",
 		} {
 			manifest.MainSection.Delete(attr)
+		}
+		buf := bytes.NewBuffer(nil)
+		if err := WriteManifest(buf, manifest); err != nil {
+			return
+		}
+		zf.SetContent(buf.Bytes())
+	},
+}
+
+var StableJARSignatureFiles = ZipEntryStabilizer{
+	Name: "jar-signatures",
+	Func: func(zf *MutableZipFile) {
+		if !strings.HasSuffix(zf.Name, ".SF") &&
+			!strings.HasSuffix(zf.Name, ".RSA") &&
+			!strings.HasSuffix(zf.Name, ".DSA") {
+			return
+		}
+		// Zero out signature files
+		zf.SetContent([]byte{})
+	},
+}
+
+var StableJAROrderOfAttributeValues = ZipEntryStabilizer{
+	Name: "jar-attribute-value-order",
+	Func: func(zf *MutableZipFile) {
+		if !strings.HasSuffix(zf.Name, "META-INF/MANIFEST.MF") {
+			return
+		}
+		r, err := zf.Open()
+		if err != nil {
+			return
+		}
+		manifest, err := ParseManifest(r)
+		if err != nil {
+			return
+		}
+		for _, attr := range []string{
+			"Export-Package",
+		} {
+			value, _ := manifest.MainSection.Get(attr)
+			value = strings.ReplaceAll(value, "\r", "")
+			value = strings.ReplaceAll(value, "\n", "")
+			value = strings.ReplaceAll(value, " ", "")
+			commaSeparateValues := strings.Split(value, ",")
+			sort.Strings(commaSeparateValues)
+			manifest.MainSection.Set(attr, strings.Join(commaSeparateValues, ","))
 		}
 		buf := bytes.NewBuffer(nil)
 		if err := WriteManifest(buf, manifest); err != nil {

--- a/pkg/archive/jar.go
+++ b/pkg/archive/jar.go
@@ -1,0 +1,60 @@
+package archive
+
+import (
+	"bytes"
+	"strings"
+)
+
+var StableJARBuildMetadata = ZipEntryStabilizer{
+	Name: "jar-build-metadata",
+	Func: func(zf *MutableZipFile) {
+		// Only process MANIFEST.MF files
+		if !strings.HasSuffix(zf.Name, "META-INF/MANIFEST.MF") {
+			return
+		}
+		r, err := zf.Open()
+		if err != nil {
+			return
+		}
+		manifest, err := ParseManifest(r)
+		if err != nil {
+			return
+		}
+		for _, attr := range []string{
+			"Archiver-Version",
+			"Bnd-LastModified",
+			"Build-Jdk",
+			"Build-Jdk-Spec",
+			"Build-Number",
+			"Build-Time",
+			"Built-By",
+			"Built-Date",
+			"Built-Host",
+			"Built-OS",
+			"Created-By",
+			"Hudson-Build-Number",
+			"Implementation-Build-Date",
+			"Implementation-Build-Java-Vendor",
+			"Implementation-Build-Java-Version",
+			"Implementation-Build",
+			"Jenkins-Build-Number",
+			"Originally-Created-By",
+			"Os-Version",
+			"SCM-Git-Branch",
+			"SCM-Revision",
+			"SCM-Git-Commit-Dirty",
+			"SCM-Git-Commit-ID",
+			"SCM-Git-Commit-Abbrev",
+			"SCM-Git-Commit-Description",
+			"SCM-Git-Commit-Timestamp",
+			"Source-Date-Epoch",
+		} {
+			manifest.MainSection.Delete(attr)
+		}
+		buf := bytes.NewBuffer(nil)
+		if err := WriteManifest(buf, manifest); err != nil {
+			return
+		}
+		zf.SetContent(buf.Bytes())
+	},
+}

--- a/pkg/archive/jar_test.go
+++ b/pkg/archive/jar_test.go
@@ -173,3 +173,166 @@ func TestStableJARBuildMetadata(t *testing.T) {
 		})
 	}
 }
+
+func TestStableJARSignatureFiles(t *testing.T) {
+	testCases := []struct {
+		test     string
+		input    []*ZipEntry
+		expected []*ZipEntry
+	}{
+		{
+			test: "no_signature_files",
+			input: []*ZipEntry{
+				{&zip.FileHeader{Name: "META-INF/MANIFEST.MF"}, []byte("Manifest-Version: 1.0\r\n\r\n")},
+				{&zip.FileHeader{Name: "com/example/Main.class"}, []byte("class data")},
+			},
+			expected: []*ZipEntry{
+				{&zip.FileHeader{Name: "META-INF/MANIFEST.MF"}, []byte("Manifest-Version: 1.0\r\n\r\n")},
+				{&zip.FileHeader{Name: "com/example/Main.class"}, []byte("class data")},
+			},
+		},
+		{
+			test: "all_signature_types",
+			input: []*ZipEntry{
+				{&zip.FileHeader{Name: "META-INF/MANIFEST.MF"}, []byte("Manifest-Version: 1.0\r\n\r\n")},
+				{&zip.FileHeader{Name: "META-INF/app.SF"}, []byte("Signature-Version: 1.0\r\nCreated-By: SignTool\r\n\r\n")},
+				{&zip.FileHeader{Name: "META-INF/app.RSA"}, []byte("RSA SIGNATURE CONTENT")},
+				{&zip.FileHeader{Name: "META-INF/app.DSA"}, []byte("DSA SIGNATURE CONTENT")},
+			},
+			expected: []*ZipEntry{
+				{&zip.FileHeader{Name: "META-INF/MANIFEST.MF"}, []byte("Manifest-Version: 1.0\r\n\r\n")},
+				{&zip.FileHeader{Name: "META-INF/app.SF"}, []byte{}},
+				{&zip.FileHeader{Name: "META-INF/app.RSA"}, []byte{}},
+				{&zip.FileHeader{Name: "META-INF/app.DSA"}, []byte{}},
+			},
+		},
+		{
+			test: "strict_casing",
+			input: []*ZipEntry{
+				{&zip.FileHeader{Name: "META-INF/APP.sf"}, []byte("Signature content")},
+				{&zip.FileHeader{Name: "META-INF/App.RSA"}, []byte("RSA content")},
+				{&zip.FileHeader{Name: "META-INF/app.dsa"}, []byte("DSA content")},
+			},
+			expected: []*ZipEntry{
+				{&zip.FileHeader{Name: "META-INF/APP.sf"}, []byte("Signature content")},
+				{&zip.FileHeader{Name: "META-INF/App.RSA"}, []byte{}},
+				{&zip.FileHeader{Name: "META-INF/app.dsa"}, []byte("DSA content")},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.test, func(t *testing.T) {
+			// Create input zip
+			var input bytes.Buffer
+			{
+				zw := zip.NewWriter(&input)
+				for _, entry := range tc.input {
+					orDie(entry.WriteTo(zw))
+				}
+				orDie(zw.Close())
+			}
+
+			// Process with stabilizer
+			var output bytes.Buffer
+			zr := must(zip.NewReader(bytes.NewReader(input.Bytes()), int64(input.Len())))
+			err := StabilizeZip(zr, zip.NewWriter(&output), StabilizeOpts{
+				Stabilizers: []any{StableJARSignatureFiles},
+			})
+			if err != nil {
+				t.Fatalf("StabilizeZip(%v) = %v, want nil", tc.test, err)
+			}
+
+			// Check output
+			var got []ZipEntry
+			{
+				zr := must(zip.NewReader(bytes.NewReader(output.Bytes()), int64(output.Len())))
+				for _, ent := range zr.File {
+					got = append(got, ZipEntry{&ent.FileHeader, must(io.ReadAll(must(ent.Open())))})
+				}
+			}
+
+			if len(got) != len(tc.expected) {
+				t.Fatalf("StabilizeZip(%v) got %v entries, want %v", tc.test, len(got), len(tc.expected))
+			}
+
+			for i := range got {
+				if !all(
+					got[i].FileHeader.Name == tc.expected[i].FileHeader.Name,
+					bytes.Equal(got[i].Body, tc.expected[i].Body),
+				) {
+					t.Errorf("Entry %d of %v:\r\ngot:  %+v\r\nwant: %+v", i, tc.test, got[i], tc.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestStableOrderOfAttributeValues(t *testing.T) {
+	testCases := []struct {
+		test     string
+		input    []*ZipEntry
+		expected []*ZipEntry
+	}{
+		{
+			test: "order_of_attribute_values",
+			input: []*ZipEntry{
+				{
+					&zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
+					[]byte("Export-Package: org.slf4j.ext;version=\"2.0.6\";uses:=\"org.slf4j\",org.slf4\n j.agent;version=\"2.0.6\",org.slf4j.instrumentation;uses:=javassist;versi\n on=\"2.0.6\",org.slf4j.cal10n;version=\"2.0.6\";uses:=\"ch.qos.cal10n,org.sl\n f4j,org.slf4j.ext\",org.slf4j.profiler;version=\"2.0.6\";uses:=\"org.slf4j\""),
+				},
+			},
+			expected: []*ZipEntry{
+				{
+					&zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
+					[]byte("Export-Package: org.slf4j,org.slf4j.agent;version=\"2.0.6\",org.slf4j.cal10n;version=\"2.0.6\";uses:=\"ch.qos.cal10n,org.slf4j.ext\",org.slf4j.ext;version=\"2.0.6\";uses:=\"org.slf4j\",org.slf4j.instrumentation;uses:=javassist;version=\"2.0.6\",org.slf4j.profiler;version=\"2.0.6\";uses:=\"org.slf4j\",org.slf4j;version=\"2.0.6\""),
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.test, func(t *testing.T) {
+			// Create input zip
+			var input bytes.Buffer
+			{
+				zw := zip.NewWriter(&input)
+				for _, entry := range tc.input {
+					orDie(entry.WriteTo(zw))
+				}
+				orDie(zw.Close())
+			}
+
+			// Process with stabilizer
+			var output bytes.Buffer
+			zr := must(zip.NewReader(bytes.NewReader(input.Bytes()), int64(input.Len())))
+			err := StabilizeZip(zr, zip.NewWriter(&output), StabilizeOpts{
+				Stabilizers: []any{StableJAROrderOfAttributeValues},
+			})
+			if err != nil {
+				t.Fatalf("StabilizeZip(%v) = %v, want nil", tc.test, err)
+			}
+
+			// Check output
+			var got []ZipEntry
+			{
+				zr := must(zip.NewReader(bytes.NewReader(output.Bytes()), int64(output.Len())))
+				for _, ent := range zr.File {
+					got = append(got, ZipEntry{&ent.FileHeader, must(io.ReadAll(must(ent.Open())))})
+				}
+			}
+
+			if len(got) != len(tc.expected) {
+				t.Fatalf("StabilizeZip(%v) got %v entries, want %v", tc.test, len(got), len(tc.expected))
+			}
+
+			for i := range got {
+				if !all(
+					got[i].FileHeader.Name == tc.expected[i].FileHeader.Name,
+					bytes.Equal(got[i].Body, tc.expected[i].Body),
+				) {
+					t.Errorf("Entry %d of %v:\r\ngot:  %+v\r\nwant: %+v", i, tc.test, string(got[i].Body), string(tc.expected[i].Body))
+				}
+			}
+		})
+	}
+}

--- a/pkg/archive/jar_test.go
+++ b/pkg/archive/jar_test.go
@@ -1,0 +1,175 @@
+package archive
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestStableJARBuildMetadata(t *testing.T) {
+	testCases := []struct {
+		test     string
+		input    []*ZipEntry
+		expected []*ZipEntry
+	}{
+		{
+			test: "non_manifest_file",
+			input: []*ZipEntry{
+				{&zip.FileHeader{Name: "src/main/java/App.class"}, []byte("class content")},
+			},
+			expected: []*ZipEntry{
+				{&zip.FileHeader{Name: "src/main/java/App.class"}, []byte("class content")},
+			},
+		},
+		{
+			test: "simple_manifest",
+			input: []*ZipEntry{
+				{
+					&zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
+					[]byte("Manifest-Version: 1.0\r\nCreated-By: Maven\r\nBuild-Jdk: 11.0.12\r\n\r\n"),
+				},
+			},
+			expected: []*ZipEntry{
+				{
+					&zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
+					[]byte("Manifest-Version: 1.0\r\n\r\n"),
+				},
+			},
+		},
+		{
+			test: "complex_manifest_with_sections",
+			input: []*ZipEntry{
+				{
+					&zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
+					[]byte("Manifest-Version: 1.0\r\nCreated-By: Maven\r\nBuild-Jdk: 11.0.12\r\n\r\nName: org/example/\r\nImplementation-Title: Example\r\n\r\n"),
+				},
+			},
+			expected: []*ZipEntry{
+				{
+					&zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
+					[]byte("Manifest-Version: 1.0\r\n\r\nName: org/example/\r\nImplementation-Title: Example\r\n\r\n"),
+				},
+			},
+		},
+		{
+			test: "keep_metadata_in_entries",
+			input: []*ZipEntry{
+				{
+					&zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
+					[]byte("Manifest-Version: 1.0\r\n\r\nName: org/example/\r\nCreated-By: Maven\r\n\r\n"),
+				},
+			},
+			expected: []*ZipEntry{
+				{
+					&zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
+					[]byte("Manifest-Version: 1.0\r\n\r\nName: org/example/\r\nCreated-By: Maven\r\n\r\n"),
+				},
+			},
+		},
+		{
+			test: "multiple_files_with_manifest",
+			input: []*ZipEntry{
+				{&zip.FileHeader{Name: "META-INF/MANIFEST.MF"}, []byte("Manifest-Version: 1.0\r\nBuild-Jdk: 11.0.12\r\nBuild-Time: 2024-01-22\r\n\r\n")},
+				{&zip.FileHeader{Name: "com/example/Main.class"}, []byte("class data")},
+				{&zip.FileHeader{Name: "META-INF/maven/project.properties"}, []byte("version=1.0.0")},
+			},
+			expected: []*ZipEntry{
+				{&zip.FileHeader{Name: "META-INF/MANIFEST.MF"}, []byte("Manifest-Version: 1.0\r\n\r\n")},
+				{&zip.FileHeader{Name: "com/example/Main.class"}, []byte("class data")},
+				{&zip.FileHeader{Name: "META-INF/maven/project.properties"}, []byte("version=1.0.0")},
+			},
+		},
+		{
+			test: "all_build_metadata_attributes",
+			input: []*ZipEntry{
+				{
+					&zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
+					[]byte(
+						"Manifest-Version: 1.0\r\n" +
+							"Archiver-Version: 1.0\r\n" +
+							"Bnd-LastModified: 1671890378000\r\n" +
+							"Build-Jdk: 11.0.12\r\n" +
+							"Build-Jdk-Spec: 11\r\n" +
+							"Build-Number: 123\r\n" +
+							"Build-Time: 2024-01-22\r\n" +
+							"Built-By: jenkins\r\n" +
+							"Built-Date: 2024-01-22\r\n" +
+							"Built-Host: build-server\r\n" +
+							"Built-OS: Linux\r\n" +
+							"Created-By: Maven\r\n" +
+							"Hudson-Build-Number: 456\r\n" +
+							"Implementation-Build-Date: 2024-01-22\r\n" +
+							"Implementation-Build-Java-Vendor: Oracle\r\n" +
+							"Implementation-Build-Java-Version: 11.0.12\r\n" +
+							"Implementation-Build: 789\r\n" +
+							"Jenkins-Build-Number: 012\r\n" +
+							"Originally-Created-By: Maven\r\n" +
+							"Os-Version: Linux 5.15\r\n" +
+							"SCM-Git-Branch: main\r\n" +
+							"SCM-Revision: abcdef\r\n" +
+							"SCM-Git-Commit-Dirty: false\r\n" +
+							"SCM-Git-Commit-ID: abcdef123456\r\n" +
+							"SCM-Git-Commit-Abbrev: abcdef\r\n" +
+							"SCM-Git-Commit-Description: feat: new feature\r\n" +
+							"SCM-Git-Commit-Timestamp: 1671890378\r\n" +
+							"Source-Date-Epoch: 1671890378\r\n" +
+							"Implementation-Title: Test Project\r\n" +
+							"Implementation-Version: 1.0.0\r\n\r\n"),
+				},
+			},
+			expected: []*ZipEntry{
+				{
+					&zip.FileHeader{Name: "META-INF/MANIFEST.MF"},
+					[]byte("Manifest-Version: 1.0\r\nImplementation-Title: Test Project\r\nImplementation-Version: 1.0.0\r\n\r\n"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.test, func(t *testing.T) {
+			// Create input zip
+			var input bytes.Buffer
+			{
+				zw := zip.NewWriter(&input)
+				for _, entry := range tc.input {
+					orDie(entry.WriteTo(zw))
+				}
+				orDie(zw.Close())
+			}
+
+			// Process with stabilizer
+			var output bytes.Buffer
+			zr := must(zip.NewReader(bytes.NewReader(input.Bytes()), int64(input.Len())))
+			err := StabilizeZip(zr, zip.NewWriter(&output), StabilizeOpts{
+				Stabilizers: []any{StableJARBuildMetadata},
+			})
+			if err != nil {
+				t.Fatalf("StabilizeZip(%v) = %v, want nil", tc.test, err)
+			}
+
+			// Check output
+			var got []ZipEntry
+			{
+				zr := must(zip.NewReader(bytes.NewReader(output.Bytes()), int64(output.Len())))
+				for _, ent := range zr.File {
+					got = append(got, ZipEntry{&ent.FileHeader, must(io.ReadAll(must(ent.Open())))})
+				}
+			}
+
+			if len(got) != len(tc.expected) {
+				t.Fatalf("StabilizeZip(%v) got %v entries, want %v", tc.test, len(got), len(tc.expected))
+			}
+
+			for i := range got {
+				if !all(
+					got[i].FileHeader.Name == tc.expected[i].FileHeader.Name,
+					bytes.Equal(got[i].Body, tc.expected[i].Body),
+				) {
+					t.Errorf("Entry %d of %v:\r\ngot:  %+v\r\nwant: %+v", i, tc.test, string(got[i].Body), string(tc.expected[i].Body))
+				}
+			}
+		})
+	}
+}

--- a/pkg/archive/manifest.go
+++ b/pkg/archive/manifest.go
@@ -1,0 +1,236 @@
+package archive
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Implements MANIFEST.MF spec: https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#JARManifest
+
+// Section represents a section in the manifest file
+type Section struct {
+	// Attributes maintains the mapping of names to values for quick lookup
+	Attributes map[string]string
+	// Order maintains the original order of attributes
+	Order []string
+}
+
+// NewSection creates a new section
+func NewSection() *Section {
+	return &Section{
+		Attributes: make(map[string]string),
+		Order:      make([]string, 0),
+	}
+}
+
+// Set adds or updates an attribute while maintaining order
+func (s *Section) Set(name, value string) {
+	if _, exists := s.Attributes[name]; !exists {
+		s.Order = append(s.Order, name)
+	}
+	s.Attributes[name] = value
+}
+
+// Get retrieves an attribute value
+func (s *Section) Get(name string) (string, bool) {
+	v, ok := s.Attributes[name]
+	return v, ok
+}
+
+// Delete removes an attribute
+func (s *Section) Delete(name string) {
+	if _, ok := s.Attributes[name]; !ok {
+		return
+	}
+	delete(s.Attributes, name)
+	for i, n := range s.Order {
+		if n == name {
+			s.Order = append(s.Order[:i], s.Order[i+1:]...)
+			break
+		}
+	}
+}
+
+// Manifest represents a parsed MANIFEST.MF file
+type Manifest struct {
+	MainSection     *Section
+	EntrySections   []*Section
+	OriginalContent []byte // Keep original content for modification
+}
+
+// NewManifest creates a new empty manifest
+func NewManifest() *Manifest {
+	return &Manifest{
+		MainSection:   &Section{Attributes: make(map[string]string)},
+		EntrySections: make([]*Section, 0),
+	}
+}
+
+// ParseManifest parses a manifest file from a reader
+func ParseManifest(r io.Reader) (*Manifest, error) {
+	content, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("reading manifest: %w", err)
+	}
+
+	content = normalizeLineEndings(content)
+
+	manifest := NewManifest()
+	manifest.OriginalContent = content
+	reader := bufio.NewReader(bytes.NewReader(content))
+
+	currentSection := manifest.MainSection
+	var currentLine, continuationLine string
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil && err != io.EOF {
+			return nil, errors.Wrap(err, "reading line")
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if strings.HasPrefix(line, " ") {
+			// Continuation line
+			if currentLine == "" {
+				return nil, errors.New("unexpected continuation line")
+			}
+			continuationLine += strings.TrimPrefix(line, " ")
+			continue
+		}
+		currentLine += continuationLine
+		continuationLine = ""
+		if err := processManifestLine(currentSection, currentLine); err != nil {
+			return nil, err
+		}
+		currentLine = line
+		if line == "" {
+			// Section separator
+			if currentSection != manifest.MainSection && len(currentSection.Order) > 0 {
+				manifest.EntrySections = append(manifest.EntrySections, currentSection)
+			}
+			currentSection = NewSection()
+			if err == io.EOF {
+				break
+			}
+		} else if err == io.EOF {
+			return nil, errors.New("missing trailing newline")
+		}
+	}
+	return manifest, nil
+}
+
+// processManifestLine processes a single manifest line and adds it to the section
+func processManifestLine(section *Section, line string) error {
+	if line == "" {
+		return nil
+	}
+	colonIdx := strings.Index(line, ":")
+	if colonIdx == -1 {
+		return fmt.Errorf("invalid manifest line (missing colon): %s", line)
+	}
+	name := strings.TrimSpace(line[:colonIdx])
+	value := strings.TrimPrefix(line[colonIdx+1:], " ")
+	if err := validateName(name); err != nil {
+		return fmt.Errorf("invalid name '%s': %w", name, err)
+	}
+	if _, exists := section.Get(name); exists {
+		return fmt.Errorf("duplicate attribute: %s", name)
+	}
+	section.Set(name, value)
+	return nil
+}
+
+// validateName checks if a manifest attribute name is valid
+func validateName(name string) error {
+	if len(name) == 0 {
+		return errors.New("empty name")
+	}
+	for _, c := range name {
+		if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+			(c >= '0' && c <= '9') || c == '-' || c == '_') {
+			return errors.Errorf("invalid character in name: %c", c)
+		}
+	}
+	// Check for "From" prefix since someone might think this is an email???
+	if strings.HasPrefix(strings.ToLower(name), "from") {
+		return errors.New("name cannot start with 'From'")
+	}
+
+	return nil
+}
+
+// WriteManifest writes a manifest back to a writer
+func WriteManifest(w io.Writer, m *Manifest) error {
+	if err := writeSection(w, m.MainSection); err != nil {
+		return err
+	}
+	for _, section := range m.EntrySections {
+		if _, err := w.Write([]byte("\r\n")); err != nil {
+			return err
+		}
+		if err := writeSection(w, section); err != nil {
+			return err
+		}
+	}
+	_, err := w.Write([]byte("\r\n"))
+	return err
+}
+
+// writeSection writes a single section to a writer
+func writeSection(w io.Writer, section *Section) error {
+	for _, name := range section.Order {
+		value, _ := section.Get(name)
+		line := fmt.Sprintf("%s: %s\r\n", name, value)
+		// Handle line length restrictions
+		if len(line) > 72 {
+			parts := splitLine(line)
+			for _, part := range parts {
+				if _, err := w.Write([]byte(part)); err != nil {
+					return err
+				}
+			}
+		} else {
+			if _, err := w.Write([]byte(line)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// splitLine splits a line longer than 72 bytes into continuation lines
+func splitLine(line string) []string {
+	var lines []string
+	remaining := line
+	for len(remaining) > 72 {
+		// Find last space before 72 bytes
+		splitIdx := 71
+		for splitIdx > 0 && remaining[splitIdx] != ' ' {
+			splitIdx--
+		}
+		if splitIdx == 0 {
+			// No space found, force split at 71
+			splitIdx = 71
+		}
+		lines = append(lines, remaining[:splitIdx+1]+"\r\n")
+		remaining = " " + remaining[splitIdx+1:]
+	}
+	if remaining != "" {
+		lines = append(lines, remaining)
+	}
+	return lines
+}
+
+// normalizeLineEndings ensures consistent CRLF line endings
+func normalizeLineEndings(data []byte) []byte {
+	// Replace Windows style (CRLF) with Unix style (LF)
+	data = bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+	// Replace Mac style (CR) with Unix style (LF)
+	data = bytes.ReplaceAll(data, []byte("\r"), []byte("\n"))
+	// Replace Unix style (LF) with Windows style (CRLF)
+	data = bytes.ReplaceAll(data, []byte("\n"), []byte("\r\n"))
+	return data
+}

--- a/pkg/archive/manifest_test.go
+++ b/pkg/archive/manifest_test.go
@@ -1,0 +1,286 @@
+package archive
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParseManifest(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantMain  map[string]string
+		wantEntry []map[string]string
+		wantErr   bool
+	}{
+		{
+			name: "basic manifest",
+			input: "Manifest-Version: 1.0\r\n" +
+				"Created-By: 1.8.0_45-b14 (Oracle Corporation)\r\n" +
+				"\r\n",
+			wantMain: map[string]string{
+				"Manifest-Version": "1.0",
+				"Created-By":       "1.8.0_45-b14 (Oracle Corporation)",
+			},
+		},
+		{
+			name: "manifest with entry",
+			input: "Manifest-Version: 1.0\r\n" +
+				"\r\n" +
+				"Name: com/example/test.class\r\n" +
+				"SHA-256-Digest: ABCDEF1234567890\r\n" +
+				"\r\n",
+			wantMain: map[string]string{
+				"Manifest-Version": "1.0",
+			},
+			wantEntry: []map[string]string{{
+				"Name":           "com/example/test.class",
+				"SHA-256-Digest": "ABCDEF1234567890",
+			}},
+		},
+		{
+			name: "manifest with continuation",
+			input: "Manifest-Version: 1.0\r\n" +
+				"Very-Long-Name: This is a very long value that should be \r\n" +
+				" continued on the next line\r\n" +
+				"\r\n",
+			wantMain: map[string]string{
+				"Manifest-Version": "1.0",
+				"Very-Long-Name":   "This is a very long value that should be continued on the next line",
+			},
+		},
+		{
+			name: "manifest with multiple entries",
+			input: "Manifest-Version: 1.0\r\n" +
+				"\r\n" +
+				"Name: file1.class\r\n" +
+				"SHA-256-Digest: ABC\r\n" +
+				"\r\n" +
+				"Name: file2.class\r\n" +
+				"SHA-256-Digest: DEF\r\n" +
+				"\r\n",
+			wantMain: map[string]string{
+				"Manifest-Version": "1.0",
+			},
+			wantEntry: []map[string]string{
+				{
+					"Name":           "file1.class",
+					"SHA-256-Digest": "ABC",
+				},
+				{
+					"Name":           "file2.class",
+					"SHA-256-Digest": "DEF",
+				},
+			},
+		},
+		{
+			name: "manifest with different line endings",
+			input: "Manifest-Version: 1.0\n" +
+				"Created-By: test\r" +
+				"Build-Jdk: 11\r\n" +
+				"\n",
+			wantMain: map[string]string{
+				"Manifest-Version": "1.0",
+				"Created-By":       "test",
+				"Build-Jdk":        "11",
+			},
+		},
+		{
+			name: "invalid manifest - no colon",
+			input: "Manifest-Version: 1.0\r\n" +
+				"Invalid Line\r\n" +
+				"\r\n",
+			wantErr: true,
+		},
+		{
+			name: "invalid manifest - duplicate attribute",
+			input: "Manifest-Version: 1.0\r\n" +
+				"Created-By: test1\r\n" +
+				"Created-By: test2\r\n" +
+				"\r\n",
+			wantErr: true,
+		},
+		{
+			name: "invalid manifest - invalid name character",
+			input: "Manifest-Version: 1.0\r\n" +
+				"Invalid@Name: value\r\n" +
+				"\r\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := strings.NewReader(tt.input)
+			got, err := ParseManifest(r)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseManifest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(got.MainSection.Attributes, tt.wantMain); diff != "" {
+				t.Errorf("Main section differs: (-got,+want)\n%s", diff)
+			}
+
+			var sections []map[string]string
+			for _, section := range got.EntrySections {
+				sections = append(sections, section.Attributes)
+			}
+			if diff := cmp.Diff(sections, tt.wantEntry); diff != "" {
+				t.Errorf("Entry sections differ: (-got,+want)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestParseManifestOrder(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		wantMainOrder []string
+		wantErr       bool
+	}{
+		{
+			name: "main attributes order",
+			input: "Manifest-Version: 1.0\r\n" +
+				"Created-By: test\r\n" +
+				"Built-By: user\r\n" +
+				"\r\n",
+			wantMainOrder: []string{
+				"Manifest-Version",
+				"Created-By",
+				"Built-By",
+			},
+		},
+		{
+			name: "manifest version required first",
+			input: "Created-By: test\r\n" +
+				"Manifest-Version: 1.0\r\n" +
+				"Built-By: user\r\n" +
+				"\r\n",
+			wantMainOrder: []string{
+				"Created-By",
+				"Manifest-Version",
+				"Built-By",
+			},
+		},
+		{
+			name: "with continuation line order",
+			input: "Manifest-Version: 1.0\r\n" +
+				"Long-Attribute: This is a very long value that should \r\n" +
+				" be continued on the next line\r\n" +
+				"Short-Attribute: value\r\n" +
+				"\r\n",
+			wantMainOrder: []string{
+				"Manifest-Version",
+				"Long-Attribute",
+				"Short-Attribute",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := strings.NewReader(tt.input)
+			got, err := ParseManifest(r)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseManifest() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil {
+				return
+			}
+
+			// Check main section order
+			if len(got.MainSection.Order) != len(tt.wantMainOrder) {
+				t.Errorf("Main section order length = %d, want %d",
+					len(got.MainSection.Order), len(tt.wantMainOrder))
+			}
+			for i, name := range tt.wantMainOrder {
+				if got.MainSection.Order[i] != name {
+					t.Errorf("Main section order[%d] = %s, want %s",
+						i, got.MainSection.Order[i], name)
+				}
+			}
+		})
+	}
+}
+
+func TestWriteManifestOrder(t *testing.T) {
+	tests := []struct {
+		name     string
+		manifest *Manifest
+		want     string
+	}{
+		{
+			name: "write ordered attributes",
+			manifest: func() *Manifest {
+				m := NewManifest()
+				m.MainSection.Set("Manifest-Version", "1.0")
+				m.MainSection.Set("Created-By", "test")
+				m.MainSection.Set("Built-By", "user")
+				return m
+			}(),
+			want: "Manifest-Version: 1.0\r\n" +
+				"Created-By: test\r\n" +
+				"Built-By: user\r\n" +
+				"\r\n",
+		},
+		{
+			name: "write with continuation lines",
+			manifest: func() *Manifest {
+				m := NewManifest()
+				m.MainSection.Set("Manifest-Version", "1.0")
+				m.MainSection.Set("Long-Attribute",
+					"This is a very long value that should be continued on the next line")
+				return m
+			}(),
+			want: "Manifest-Version: 1.0\r\n" +
+				"Long-Attribute: This is a very long value that should be continued on \r\n" +
+				" the next line\r\n" +
+				"\r\n",
+		},
+		{
+			name: "write multiple sections",
+			manifest: func() *Manifest {
+				m := NewManifest()
+				m.MainSection.Set("Manifest-Version", "1.0")
+
+				section := NewSection()
+				section.Set("Name", "test.class")
+				section.Set("SHA-256-Digest", "ABC")
+				m.EntrySections = append(m.EntrySections, section)
+				return m
+			}(),
+			want: "Manifest-Version: 1.0\r\n" +
+				"\r\n" +
+				"Name: test.class\r\n" +
+				"SHA-256-Digest: ABC\r\n" +
+				"\r\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := WriteManifest(&buf, tt.manifest)
+			if err != nil {
+				t.Errorf("WriteManifest() error = %v", err)
+				return
+			}
+
+			got := buf.String()
+			if got != tt.want {
+				t.Errorf("WriteManifest() =\n%q\nwant:\n%q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/archive/tar.go
+++ b/pkg/archive/tar.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package archive
 

--- a/pkg/archive/tar_test.go
+++ b/pkg/archive/tar_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package archive
 

--- a/pkg/archive/zip.go
+++ b/pkg/archive/zip.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package archive
 

--- a/pkg/archive/zip_test.go
+++ b/pkg/archive/zip_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package archive
 

--- a/pkg/builddef/set.go
+++ b/pkg/builddef/set.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package builddef
 

--- a/pkg/feed/grouping.go
+++ b/pkg/feed/grouping.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package feed
 
 import (

--- a/pkg/feed/grouping_test.go
+++ b/pkg/feed/grouping_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package feed
 
 import (

--- a/pkg/feed/tracker.go
+++ b/pkg/feed/tracker.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package feed
 
 import (

--- a/pkg/kmsdsse/kmsdsse.go
+++ b/pkg/kmsdsse/kmsdsse.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package kmsdsse
 

--- a/pkg/proxy/cert/cert.go
+++ b/pkg/proxy/cert/cert.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 // Package cert provides certificate generation and formatting interfaces.
 package cert
 

--- a/pkg/proxy/docker/docker.go
+++ b/pkg/proxy/docker/docker.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 // Package docker defines a proxy for the Docker API.
 //
 // Summary: Change the internal container state transparently while providing

--- a/pkg/proxy/docker/docker_test.go
+++ b/pkg/proxy/docker/docker_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package docker
 
 import (

--- a/pkg/proxy/docker/linux.go
+++ b/pkg/proxy/docker/linux.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package docker
 
 import (

--- a/pkg/proxy/docker/uds.go
+++ b/pkg/proxy/docker/uds.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package docker
 
 import (

--- a/pkg/proxy/netlog/netlog.go
+++ b/pkg/proxy/netlog/netlog.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package netlog
 
 import (

--- a/pkg/proxy/policy/policy.go
+++ b/pkg/proxy/policy/policy.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 // Package policy defines the network policy that the proxy can choose to enforce.
 package policy
 

--- a/pkg/proxy/policy/policy_test.go
+++ b/pkg/proxy/policy/policy_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package policy
 
 import (

--- a/pkg/proxy/proxy/transparent.go
+++ b/pkg/proxy/proxy/transparent.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package proxy
 
 import (

--- a/pkg/proxy/proxy/transparent_test.go
+++ b/pkg/proxy/proxy/transparent_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package proxy
 
 import (

--- a/pkg/rebuild/cratesio/infer.go
+++ b/pkg/rebuild/cratesio/infer.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package cratesio
 

--- a/pkg/rebuild/cratesio/infer_test.go
+++ b/pkg/rebuild/cratesio/infer_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package cratesio
 
 import (

--- a/pkg/rebuild/cratesio/rebuild.go
+++ b/pkg/rebuild/cratesio/rebuild.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package cratesio
 

--- a/pkg/rebuild/cratesio/rebuild_test.go
+++ b/pkg/rebuild/cratesio/rebuild_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package cratesio
 

--- a/pkg/rebuild/cratesio/strategy.go
+++ b/pkg/rebuild/cratesio/strategy.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package cratesio
 

--- a/pkg/rebuild/cratesio/strategy_test.go
+++ b/pkg/rebuild/cratesio/strategy_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package cratesio
 

--- a/pkg/rebuild/debian/infer.go
+++ b/pkg/rebuild/debian/infer.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package debian
 

--- a/pkg/rebuild/debian/rebuild.go
+++ b/pkg/rebuild/debian/rebuild.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package debian
 

--- a/pkg/rebuild/debian/strategy.go
+++ b/pkg/rebuild/debian/strategy.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package debian
 

--- a/pkg/rebuild/debian/strategy_test.go
+++ b/pkg/rebuild/debian/strategy_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package debian
 
 import (

--- a/pkg/rebuild/flow/flow.go
+++ b/pkg/rebuild/flow/flow.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package flow
 
 import (

--- a/pkg/rebuild/flow/flow_test.go
+++ b/pkg/rebuild/flow/flow_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package flow
 
 import (

--- a/pkg/rebuild/flow/json.go
+++ b/pkg/rebuild/flow/json.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package flow
 
 import (

--- a/pkg/rebuild/flow/tool.go
+++ b/pkg/rebuild/flow/tool.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package flow
 
 import (

--- a/pkg/rebuild/maven/infer.go
+++ b/pkg/rebuild/maven/infer.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package maven
 

--- a/pkg/rebuild/maven/pom.go
+++ b/pkg/rebuild/maven/pom.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package maven
 

--- a/pkg/rebuild/maven/pom_test.go
+++ b/pkg/rebuild/maven/pom_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package maven
 
 import (

--- a/pkg/rebuild/maven/rebuild.go
+++ b/pkg/rebuild/maven/rebuild.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package maven
 

--- a/pkg/rebuild/maven/strategy.go
+++ b/pkg/rebuild/maven/strategy.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package maven
 

--- a/pkg/rebuild/npm/infer.go
+++ b/pkg/rebuild/npm/infer.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package npm
 

--- a/pkg/rebuild/npm/infer_test.go
+++ b/pkg/rebuild/npm/infer_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package npm
 
 import (

--- a/pkg/rebuild/npm/rebuild.go
+++ b/pkg/rebuild/npm/rebuild.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package npm
 

--- a/pkg/rebuild/npm/rebuild_test.go
+++ b/pkg/rebuild/npm/rebuild_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package npm
 

--- a/pkg/rebuild/npm/strategy.go
+++ b/pkg/rebuild/npm/strategy.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package npm
 

--- a/pkg/rebuild/npm/strategy_test.go
+++ b/pkg/rebuild/npm/strategy_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package npm
 

--- a/pkg/rebuild/pypi/infer.go
+++ b/pkg/rebuild/pypi/infer.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package pypi
 

--- a/pkg/rebuild/pypi/rebuild.go
+++ b/pkg/rebuild/pypi/rebuild.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package pypi
 

--- a/pkg/rebuild/pypi/rebuild_test.go
+++ b/pkg/rebuild/pypi/rebuild_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package pypi
 

--- a/pkg/rebuild/pypi/strategy.go
+++ b/pkg/rebuild/pypi/strategy.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package pypi
 

--- a/pkg/rebuild/pypi/strategy_test.go
+++ b/pkg/rebuild/pypi/strategy_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package pypi
 

--- a/pkg/rebuild/rebuild/compare.go
+++ b/pkg/rebuild/rebuild/compare.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package rebuild provides functionality to rebuild packages.
 package rebuild

--- a/pkg/rebuild/rebuild/context.go
+++ b/pkg/rebuild/rebuild/context.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package rebuild contains interfaces implementing generic rebuild functionality.
 package rebuild

--- a/pkg/rebuild/rebuild/exec.go
+++ b/pkg/rebuild/rebuild/exec.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package rebuild
 
 import (

--- a/pkg/rebuild/rebuild/git.go
+++ b/pkg/rebuild/rebuild/git.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package rebuild
 

--- a/pkg/rebuild/rebuild/git_test.go
+++ b/pkg/rebuild/rebuild/git_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package rebuild
 
 import (

--- a/pkg/rebuild/rebuild/http.go
+++ b/pkg/rebuild/rebuild/http.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package rebuild
 

--- a/pkg/rebuild/rebuild/log.go
+++ b/pkg/rebuild/rebuild/log.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package rebuild
 

--- a/pkg/rebuild/rebuild/manualstrategy.go
+++ b/pkg/rebuild/rebuild/manualstrategy.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package rebuild
 

--- a/pkg/rebuild/rebuild/metadata.go
+++ b/pkg/rebuild/rebuild/metadata.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package rebuild
 

--- a/pkg/rebuild/rebuild/models.go
+++ b/pkg/rebuild/rebuild/models.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package rebuild
 

--- a/pkg/rebuild/rebuild/rebuild.go
+++ b/pkg/rebuild/rebuild/rebuild.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package rebuild
 

--- a/pkg/rebuild/rebuild/rebuildmany.go
+++ b/pkg/rebuild/rebuild/rebuildmany.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package rebuild
 

--- a/pkg/rebuild/rebuild/rebuildone.go
+++ b/pkg/rebuild/rebuild/rebuildone.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package rebuild
 

--- a/pkg/rebuild/rebuild/rebuildremote.go
+++ b/pkg/rebuild/rebuild/rebuildremote.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package rebuild
 

--- a/pkg/rebuild/rebuild/rebuildremote_test.go
+++ b/pkg/rebuild/rebuild/rebuildremote_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package rebuild
 

--- a/pkg/rebuild/rebuild/registry.go
+++ b/pkg/rebuild/rebuild/registry.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package rebuild
 

--- a/pkg/rebuild/rebuild/storage.go
+++ b/pkg/rebuild/rebuild/storage.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package rebuild
 

--- a/pkg/rebuild/rebuild/strategy.go
+++ b/pkg/rebuild/rebuild/strategy.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package rebuild
 

--- a/pkg/rebuild/rebuild/workflowstrategy.go
+++ b/pkg/rebuild/rebuild/workflowstrategy.go
@@ -1,16 +1,6 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package rebuild
 
 import (

--- a/pkg/rebuild/rebuild/workflowstrategy_test.go
+++ b/pkg/rebuild/rebuild/workflowstrategy_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package rebuild
 
 import (

--- a/pkg/rebuild/schema/schema.go
+++ b/pkg/rebuild/schema/schema.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package schema is a set of utilities for marshalling strategies.
 // Currently, schema only supports YAML but we may add protobuf in the future.

--- a/pkg/rebuild/schema/schema_test.go
+++ b/pkg/rebuild/schema/schema_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package schema
 

--- a/pkg/registry/cratesio/cargo.go
+++ b/pkg/registry/cratesio/cargo.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package cratesio
 

--- a/pkg/registry/cratesio/cratesio.go
+++ b/pkg/registry/cratesio/cratesio.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package cratesio provides interfaces for interacting with the crates.io API and with Cargo-specific formats.
 package cratesio

--- a/pkg/registry/cratesio/cratesio_test.go
+++ b/pkg/registry/cratesio/cratesio_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package cratesio
 

--- a/pkg/registry/cratesio/rust.go
+++ b/pkg/registry/cratesio/rust.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package cratesio
 

--- a/pkg/registry/cratesio/rust_test.go
+++ b/pkg/registry/cratesio/rust_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package cratesio
 

--- a/pkg/registry/debian/debian.go
+++ b/pkg/registry/debian/debian.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package debian
 

--- a/pkg/registry/debian/debian_test.go
+++ b/pkg/registry/debian/debian_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package debian
 

--- a/pkg/registry/maven/maven.go
+++ b/pkg/registry/maven/maven.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package maven provides an interface with Maven package registry and its API.
 package maven

--- a/pkg/registry/npm/node.go
+++ b/pkg/registry/npm/node.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package npm
 
 import (

--- a/pkg/registry/npm/npm.go
+++ b/pkg/registry/npm/npm.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package npm
 

--- a/pkg/registry/npm/npm_test.go
+++ b/pkg/registry/npm/npm_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package npm
 

--- a/pkg/registry/pypi/pypi.go
+++ b/pkg/registry/pypi/pypi.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package pypi describes the PyPi registry interface.
 package pypi

--- a/pkg/registry/pypi/pypi_test.go
+++ b/pkg/registry/pypi/pypi_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package pypi
 

--- a/tools/benchmark/benchmark.go
+++ b/tools/benchmark/benchmark.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package benchmark provides interfaces related to rebuild benchmarks.
 package benchmark

--- a/tools/benchmark/generate/main.go
+++ b/tools/benchmark/generate/main.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package main generates rebuild benchmark files from external data sources.
 package main

--- a/tools/benchmark/read.go
+++ b/tools/benchmark/read.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package benchmark
 
 import (

--- a/tools/benchmark/run.go
+++ b/tools/benchmark/run.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package benchmark
 
 import (

--- a/tools/benchmark/run_test.go
+++ b/tools/benchmark/run_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package benchmark
 
 import (

--- a/tools/ctl/ctl.go
+++ b/tools/ctl/ctl.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package main
 

--- a/tools/ctl/ide/context.go
+++ b/tools/ctl/ide/context.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package ide
 
 type ctxKey int

--- a/tools/ctl/ide/logs.go
+++ b/tools/ctl/ide/logs.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package ide
 

--- a/tools/ctl/ide/rebuilder.go
+++ b/tools/ctl/ide/rebuilder.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 package ide
 

--- a/tools/ctl/ide/ui.go
+++ b/tools/ctl/ide/ui.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package ide contains UI and state management code for the TUI rebuild debugger.
 package ide

--- a/tools/ctl/localfiles/localfiles.go
+++ b/tools/ctl/localfiles/localfiles.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package localfiles
 
 import (

--- a/tools/ctl/pipe/pipe.go
+++ b/tools/ctl/pipe/pipe.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package pipe provides a simple way of applying transforms to a channel.
 package pipe

--- a/tools/ctl/rundex/rundex.go
+++ b/tools/ctl/rundex/rundex.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package rundex provides access to metadata about runs and attempts.
 package rundex

--- a/tools/docker/docker.go
+++ b/tools/docker/docker.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package docker contains container execution APIs.
 package docker

--- a/tools/flow/main.go
+++ b/tools/flow/main.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/tools/indexscan/main.go
+++ b/tools/indexscan/main.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package main implements a repo scanning tool to identify the best ref match for an upstream artifact.
 package main

--- a/tools/pypi_rss/listener/listener.go
+++ b/tools/pypi_rss/listener/listener.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package listener
 
 import (

--- a/tools/pypi_rss/listener/listener_test.go
+++ b/tools/pypi_rss/listener/listener_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package listener
 
 import (

--- a/tools/pypi_rss/main.go
+++ b/tools/pypi_rss/main.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 // PyPI RSS Subscriber for OSS Rebuild
 // This tool is a long-running service that fetches updates from PyPI's RSS feed,
 // and adds rebuild attempts into a task queue for any release of a package that's considered "tracked".

--- a/tools/registryscan/main.go
+++ b/tools/registryscan/main.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/tools/run_local/main.go
+++ b/tools/run_local/main.go
@@ -1,16 +1,5 @@
-// Copyright 2024 The OSS Rebuild Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 Google LLC
+// SPDX-License-Identifier: Apache-2.0
 
 // Package main builds and runs a rebuild server.
 package main


### PR DESCRIPTION
Hi @msuozzo ! I added a patch to preserve the order of values. This is a problem with the order of values of attributes `Include-Resource`, `Private-Package`, `Export-Package`, and `Provide-Capability`. These are added by `maven-bundle-plugin` and the order if their values can change across rebuilds. However, this has been fixed in [later versions](https://github.com/apache/felix-dev/commit/d885d99a6a16660f655a4fd18e8a1a39beef0a15) of `maven-bundle-plugin`.

You can see this unreproducible attribute for [`org.slf4j:slf4j-ext:2.0.6`](https://github.com/qos-ch/slf4j/tree/v_2.0.6). This project is also documented in [Reproducible Central](https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/slf4j/README.md).

Also, I am not sure what is your fixing strategy? Do you prefer to always strip (most of the manifest entries) or set to some fixed value (signature)? I tried to reorder the values for these attributes to try out writing a new stabiliser and do what the fix above does, but we can strip them too.

Right now, the tests are only for `Export-Package`. They seem to fail because the setter for manifest tries to preserve space. I am not sure why it is adding spaces, but maybe you can help me look into it.